### PR TITLE
new more consistent release symlinks

### DIFF
--- a/dist/latest/freedom-for-chrome.js
+++ b/dist/latest/freedom-for-chrome.js
@@ -1,0 +1,1 @@
+../freedom-for-chrome/freedom-for-chrome.latest.js

--- a/dist/latest/freedom-for-firefox.jsm
+++ b/dist/latest/freedom-for-firefox.jsm
@@ -1,0 +1,1 @@
+../freedom-for-firefox/freedom-for-firefox.latest.jsm

--- a/dist/latest/freedom.js
+++ b/dist/latest/freedom.js
@@ -1,0 +1,1 @@
+../freedom/latest/freedom.js


### PR DESCRIPTION
Just a thought I'm having that may simplify some steps of my tutorial/generator (I want to provide people the option to get freedom from npm, bower, or just grab the .js) - these are symlinks so that the latest release of all freedom flavors is available at urls that all start with http://www.freedomjs.org/dist/latest/, e.g.:
- http://www.freedomjs.org/dist/latest/freedom.js
- http://www.freedomjs.org/dist/latest/freedom-for-chrome.js
- http://www.freedomjs.org/dist/latest/freedom-for-firefox.jsm

We can keep the existing more-buried "latest" links or not, or at least I'm indifferent on that. I do have a few more quick comments/questions on releases though:
- We don't have freedom-for-node releases on the website, but I imagine that's because there's no real point to using freedom-for-node without npm. Still, if we want to put it out there for consistency I'd be up for adding it.
- From what I can tell, bower only has vanilla freedom - any particular reason not to add the other flavors?
- Not an immediate issue, but we may want to consider delivering freedom.js via https. It doesn't look like GitHub pages supports https though, but maybe that will be added when 'Let's Encrypt' takes off.

Anyway, not blocking, but thoughts welcome. Thanks!
